### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-pond-0fc436900.yml
+++ b/.github/workflows/azure-static-web-apps-witty-pond-0fc436900.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
Potential fix for [https://github.com/samuelweiwei/selfblog/security/code-scanning/3](https://github.com/samuelweiwei/selfblog/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for the jobs. Based on the workflow's functionality:
- The `build_and_deploy_job` requires `contents: read` for accessing the repository and `statuses: write` for updating commit statuses.
- The `close_pull_request_job` does not appear to require any additional permissions beyond the default `contents: read`.

We will add the following `permissions` block to the root of the workflow:
```yaml
permissions:
  contents: read
  statuses: write
```

This ensures that the workflow has only the necessary permissions and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
